### PR TITLE
入力ページ基本見た目

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { createStackNavigator } from '@react-navigation/stack';
+import AddItemScreen from './screens/AddItemScreen';
 
 const Stack = createStackNavigator();
 
@@ -12,7 +13,9 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <NavigationContainer>
-        <Stack.Navigator></Stack.Navigator>
+        <Stack.Navigator screenOptions={{ header: () => null }}>
+          <Stack.Screen name='AddItem' component={AddItemScreen} />
+        </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@react-native-community/datetimepicker": "3.5.2",
+        "@react-native-community/datetimepicker": "^3.5.2",
         "@react-native-masked-view/masked-view": "0.2.5",
         "@react-native-picker/picker": "2.1.0",
         "@react-navigation/native": "^6.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,9 @@
   "packages": {
     "": {
       "dependencies": {
+        "@react-native-community/datetimepicker": "3.5.2",
         "@react-native-masked-view/masked-view": "0.2.5",
+        "@react-native-picker/picker": "2.1.0",
         "@react-navigation/native": "^6.0.6",
         "@react-navigation/stack": "^6.0.11",
         "expo": "~43.0.0",
@@ -2813,10 +2815,27 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-3.5.2.tgz",
+      "integrity": "sha512-TWRuAtr/DnrEcRewqvXMLea2oB+YF+SbtuYLHguALLxNJQLl/RFB7aTNZeF+OoH75zKFqtXECXV1/uxQUpA+sg==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      }
+    },
     "node_modules/@react-native-masked-view/masked-view": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.5.tgz",
       "integrity": "sha512-yXaWyV8xu1N5tfdfP8L29U0TIDvBriN4zHUI+Zs7Sw+VI8pBbEEYoITK9aFt495Y0/PPm4FsTpa35hOeTLfGPA==",
+      "peerDependencies": {
+        "react": "16 || 17",
+        "react-native": ">=0.57"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.1.0.tgz",
+      "integrity": "sha512-iJ/QaDrBMBaW6cFuQyR3DXzcn2h7c5O7mGgmNLCBQHTTtLNBZR+Sxogy6YleFPeToNdysG5mTTkXqBmlWHMQqg==",
       "peerDependencies": {
         "react": "16 || 17",
         "react-native": ">=0.57"
@@ -12177,10 +12196,24 @@
         "ora": "^3.4.0"
       }
     },
+    "@react-native-community/datetimepicker": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-3.5.2.tgz",
+      "integrity": "sha512-TWRuAtr/DnrEcRewqvXMLea2oB+YF+SbtuYLHguALLxNJQLl/RFB7aTNZeF+OoH75zKFqtXECXV1/uxQUpA+sg==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "@react-native-masked-view/masked-view": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.5.tgz",
       "integrity": "sha512-yXaWyV8xu1N5tfdfP8L29U0TIDvBriN4zHUI+Zs7Sw+VI8pBbEEYoITK9aFt495Y0/PPm4FsTpa35hOeTLfGPA==",
+      "requires": {}
+    },
+    "@react-native-picker/picker": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.1.0.tgz",
+      "integrity": "sha512-iJ/QaDrBMBaW6cFuQyR3DXzcn2h7c5O7mGgmNLCBQHTTtLNBZR+Sxogy6YleFPeToNdysG5mTTkXqBmlWHMQqg==",
       "requires": {}
     },
     "@react-native/assets": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "^3.5.2",
     "@react-native-masked-view/masked-view": "0.2.5",
+    "@react-native-picker/picker": "2.1.0",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/stack": "^6.0.11",
     "expo": "~43.0.0",
@@ -19,9 +21,7 @@
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "^3.3.2",
-    "react-native-web": "0.17.1",
-    "@react-native-community/datetimepicker": "3.5.2",
-    "@react-native-picker/picker": "2.1.0"
+    "react-native-web": "0.17.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "^3.3.2",
-    "react-native-web": "0.17.1"
+    "react-native-web": "0.17.1",
+    "@react-native-community/datetimepicker": "3.5.2",
+    "@react-native-picker/picker": "2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/screens/AddItemScreen.js
+++ b/screens/AddItemScreen.js
@@ -1,0 +1,101 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Button, Card, Input, Text } from 'react-native-elements';
+import { Picker } from '@react-native-picker/picker';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+const categories = [
+  {
+    label: '麺類',
+    value: 'noddle',
+  },
+  { label: '米', value: 'rice' },
+];
+
+const AddItemScreen = () => {
+  const [itemName, setItemName] = useState('');
+  const [category, setCategory] = useState('noddle');
+  const currentDate = new Date();
+  const [expiryDate, setExpiryDate] = useState(currentDate);
+  const [errors, setErrors] = useState({
+    itemName: '',
+    expiryDate: '',
+    category: '',
+  });
+
+  const handleCategoryChange = useCallback(
+    (itemValue, itemIndex) => setCategory(itemValue),
+    []
+  );
+
+  const handleExpiryDateChange = useCallback(
+    (e, date) => setExpiryDate(date),
+    []
+  );
+
+  const handelAddItem = useCallback(() => {
+    if (!itemName) {
+      setErrors((prevState) => ({
+        ...prevState,
+        itemName: '名前を入力してください',
+      }));
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Card containerStyle={styles.card} wrapperStyle={styles.cardContent}>
+        <Card.Title>
+          <Text h1>アイテム詳細</Text>
+        </Card.Title>
+        <Text h3>名前</Text>
+        <Input
+          autoCompleteType='off'
+          onChangeText={setItemName}
+          value={itemName}
+          placeholder='カップ麺'
+          errorMessage={errors.itemName}
+        ></Input>
+        <Text h3>賞味期限</Text>
+        <DateTimePicker
+          minimumDate={currentDate}
+          value={expiryDate}
+          style={styles.datePicker}
+          onChange={handleExpiryDateChange}
+        ></DateTimePicker>
+        <Text h3>カテゴリ</Text>
+        <Picker selectedValue={category} onValueChange={handleCategoryChange}>
+          {categories.map((category) => (
+            <Picker.Item
+              key={category.label}
+              label={category.label}
+              value={category.value}
+            />
+          ))}
+        </Picker>
+        <Button onPress={handelAddItem} type='solid' title='追加する' />
+      </Card>
+    </View>
+  );
+};
+
+export default AddItemScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 30,
+    marginBottom: 30,
+    flex: 1,
+  },
+  cardContent: {
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'space-between',
+    flex: 1,
+  },
+  card: {
+    flex: 1,
+  },
+  categoryPicker: { height: '20%' },
+  datePicker: { alignSelf: 'center', width: '40%' },
+});


### PR DESCRIPTION
内容
入力ページ基本の見た目を作成、Main.jsにスクリーンとして追加

コメント
React Native ElementsにPickerコンポーネントがないため、@react-native-community/datetimepickerと@react-native-picker/pickerパッケージをdependenciesに追加
スタイリングは大雑把

写真
![Simulator Screen Shot - iPhone 13 - 2021-10-26 at 22 08 29](https://user-images.githubusercontent.com/36330958/138885363-36630d51-7909-4412-97f6-06e0dafd4ad2.png)
